### PR TITLE
Don't render script tag when JavaScript check is disabled

### DIFF
--- a/src/Views/Honey.php
+++ b/src/Views/Honey.php
@@ -20,23 +20,25 @@ class Honey extends Component
     public function render()
     {
         return <<<'blade'
-                @once
-                    <script>
-                        window.addEventListener('load', () => {
-                            setTimeout(() => {
-                                document.querySelectorAll('input[data-purpose="{{ $inputNameSelector->getJavascriptInputName() }}"]')
-                                    .forEach(input => {
-                                        if (input.value.length > 0) {
-                                            return;
-                                        }
-                                        
-                                        input.value = "{{ $javascriptValue() }}";
-                                        input.dispatchEvent(new Event('change'));
-                                    });
-                            }, {{ $javascriptTimeout() }})
-                        });
-                    </script>
-                @endonce
+               @if (in_array(\Lukeraymonddowning\Honey\Checks\JavascriptInputFilledCheck::class, config('honey.checks')))
+                    @once
+                        <script>
+                            window.addEventListener('load', () => {
+                                setTimeout(() => {
+                                    document.querySelectorAll('input[data-purpose="{{ $inputNameSelector->getJavascriptInputName() }}"]')
+                                        .forEach(input => {
+                                            if (input.value.length > 0) {
+                                                return;
+                                            }
+                                            
+                                            input.value = "{{ $javascriptValue() }}";
+                                            input.dispatchEvent(new Event('change'));
+                                        });
+                                }, {{ $javascriptTimeout() }})
+                            });
+                        </script>
+                    @endonce
+                @endif
                 <div style="display: @isset($attributes['debug']) block @else none @endisset;">
                     <input wire:model.lazy.defer="honeyInputs.{{ $inputNameSelector->getPresentButEmptyInputName() }}" name="{{ $inputNameSelector->getPresentButEmptyInputName() }}" value="">
                     <input wire:model.lazy.defer="honeyInputs.{{ $inputNameSelector->getTimeOfPageLoadInputName() }}" name="{{ $inputNameSelector->getTimeOfPageLoadInputName() }}" value="{{ $timeOfPageLoadValue() }}">


### PR DESCRIPTION
I'm using Honey alongside Vue 3, and I'm getting a console warning saying that the script tags will be ignored by Vue. For some reason, when compiling the production JavaScript build, the script tag triggers a syntax error, resulting in a blank page. 

I’ve been using the fix supplied in this PR and that solves this problem for me. Although I’m not sure if this causes a problem if you’re using Honey in a stand-alone way, without the config file (I’m not sure if that is supported). 