### PR TITLE
Add `down()` method in spammers migration file

### DIFF
--- a/database/migrations/2020_11_26_000000_create_spammers_table.php
+++ b/database/migrations/2020_11_26_000000_create_spammers_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 class CreateSpammersTable extends Migration
@@ -10,7 +11,7 @@ class CreateSpammersTable extends Migration
     {
         Schema::create(
             config('honey.spammer_blocking.table_name', 'spammers'),
-            function ($table) {
+            function (Blueprint $table) {
                 $table->id();
                 $table->string('ip_address');
                 $table->integer('attempts');
@@ -18,6 +19,11 @@ class CreateSpammersTable extends Migration
                 $table->timestamps();
             }
         );
+    }
+    
+    public function down()
+    {
+        Schema::dropIfExists(config('honey.spammer_blocking.table_name', 'spammers'));
     }
 
 }


### PR DESCRIPTION
For example when running migrations in [Dusk](https://laravel.com/docs/dusk) tests the migrations get purged after the tests and leaving the `spammers` table behind because of the missing `down()` method. The `migrations` database table does not keep track of that and therefore running `php artisan migrate` fails because the `spammers` table already exists.