### PR TITLE
Add `enable()` method to Honey

### DIFF
--- a/src/Honey.php
+++ b/src/Honey.php
@@ -42,7 +42,7 @@ class Honey
         $this->isEnabled = false;
     }
     
-    public function disable()
+    public function enable()
     {
         $this->isEnabled = true;
     }

--- a/src/Honey.php
+++ b/src/Honey.php
@@ -41,6 +41,11 @@ class Honey
     {
         $this->isEnabled = false;
     }
+    
+    public function disable()
+    {
+        $this->isEnabled = true;
+    }
 
     protected function registerSpammerTracking()
     {

--- a/tests/ManualDisableTest.php
+++ b/tests/ManualDisableTest.php
@@ -4,18 +4,22 @@
 namespace Lukeraymonddowning\Honey\Tests;
 
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Lukeraymonddowning\Honey\Facades\Honey;
 use Lukeraymonddowning\Honey\Http\Middleware\CheckRecaptchaToken;
 
+
 class ManualDisableTest extends TestCase
 {
-    
+
     /** @test */
-    public function it_can_be_disabled_manually()
+    public function it_can_be_disabled_and_enabled_manually()
     {
         $this->assertTrue(Honey::isEnabled());
         Honey::disable();
         $this->assertFalse(Honey::isEnabled());
+        Honey::enable();
+        $this->assertTrue(Honey::isEnabled());
     }
 
     /** @test */
@@ -33,5 +37,20 @@ class ManualDisableTest extends TestCase
             throw new \Exception("Hello world");
         });
     }
-    
+
+    /** @test */
+    public function the_recaptcha_middleware_stack_does_not_complete_when_enabled_again()
+    {
+        Honey::disable();
+        Honey::enable();
+
+        $this->expectExceptionObject(new HTTPException(422, 'You shall not pass!'));
+
+        $middleware = new CheckRecaptchaToken();
+
+        $request = request()->replace([Honey::inputs()->getRecaptchaInputName() => 'foobar']);
+
+        $middleware->handle($request, function() {});
+    }
+
 }

--- a/tests/ManualEnableDisableTest.php
+++ b/tests/ManualEnableDisableTest.php
@@ -9,7 +9,7 @@ use Lukeraymonddowning\Honey\Facades\Honey;
 use Lukeraymonddowning\Honey\Http\Middleware\CheckRecaptchaToken;
 
 
-class ManualDisableTest extends TestCase
+class ManualEnableDisableTest extends TestCase
 {
 
     /** @test */


### PR DESCRIPTION
Hi there! 👋  During testing I found it useful to enable Honey inside my testing logic. To do so I added an `enable` method, which is simply the opposite of the `disable` method. In my case this worked seamlessly with my tests. So I think, it might be handy for others as well.