### PR TITLE
Only check POST methods

### DIFF
--- a/src/Http/Middleware/PreventSpam.php
+++ b/src/Http/Middleware/PreventSpam.php
@@ -11,7 +11,11 @@ class PreventSpam
 
     public function handle(Request $request, callable $next)
     {
-        return Honey::check($request->all()) ? $next($request) : Honey::fail();
+        $method = $request->method();
+ 
+        if ($request->isMethod('post')) {
+            return Honey::check($request->all()) ? $next($request) : Honey::fail();
+        }
     }
 
 }


### PR DESCRIPTION
This would solve these kind of issues here: https://github.com/lukeraymonddowning/honey/issues/40

The use case would be applying the middleware to an entire route group that has both GET and POST requests.