### PR TITLE
fix: :bug: fixed undefined array key "honey_time" error

### DIFF
--- a/src/Checks/MinimumTimePassedCheck.php
+++ b/src/Checks/MinimumTimePassedCheck.php
@@ -9,8 +9,21 @@ use Lukeraymonddowning\Honey\InputValues\Values;
 
 class MinimumTimePassedCheck implements Check
 {
+    protected $data;
+
+    protected function missingFromData()
+    {
+        return !$this->data->offsetExists(Honey::inputs()->getTimeOfPageLoadInputName());
+    }
+
     public function passes($data)
     {
+        $this->data = collect($data);
+
+        if ($this->missingFromData()) {
+            return false;
+        }
+
         $value = $data[Honey::inputs()->getTimeOfPageLoadInputName()];
         return rescue(fn() => Values::timeOfPageLoad()->checkValue($value));
     }


### PR DESCRIPTION
After starting to use this library, spammers are trying to spoof forms, and if they do not include the `honey_time` parameter, the server will give a 500 error even in production.

To solve it, I just copied from the file `src/Checks/JavascriptInputFilledCheck.php` the logic corresponding to the validation of the submitted fields, and I adapted it for the validation of the minimum time passed that gave problems.

This fixes the issues #59 and #33.