### PR TITLE
Upgrade to livewire 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "orchestra/testbench": "^7.0|^8.0",
-    "livewire/livewire": "^2.11"
+    "livewire/livewire": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Traits/WithRecaptcha.php
+++ b/src/Traits/WithRecaptcha.php
@@ -20,7 +20,7 @@ trait WithRecaptcha
 
     public function requestRecaptchaTokenRefresh()
     {
-        $this->dispatchBrowserEvent('recaptcha-refresh-required');
+        $this->dispatch('recaptcha-refresh-required');
     }
 
     public function mountWithRecaptcha()

--- a/src/Views/Honey.php
+++ b/src/Views/Honey.php
@@ -31,7 +31,7 @@ class Honey extends Component
                                             }
 
                                             input.value = "{{ $javascriptValue() }}";
-                                            input.dispatchEvent(new Event('change'));
+                                            input.dispatchEvent(new Event('input'));
                                         });
                                 }, {{ $javascriptTimeout() }})
                             });
@@ -39,9 +39,9 @@ class Honey extends Component
                     @endonce
                 @endif
                 <div style="display: @isset($attributes['debug']) block @else none @endisset;">
-                    <input wire:model.lazy.defer="honeyInputs.{{ $inputNameSelector->getPresentButEmptyInputName() }}" name="{{ $inputNameSelector->getPresentButEmptyInputName() }}" value="">
-                    <input wire:model.lazy.defer="honeyInputs.{{ $inputNameSelector->getTimeOfPageLoadInputName() }}" name="{{ $inputNameSelector->getTimeOfPageLoadInputName() }}" value="{{ $timeOfPageLoadValue() }}">
-                    <input wire:model.lazy.defer="honeyInputs.{{ $inputNameSelector->getJavascriptInputName() }}" data-purpose="{{ $inputNameSelector->getJavascriptInputName() }}" name="{{ $inputNameSelector->getJavascriptInputName() }}" value="">
+                    <input wire:model="honeyInputs.{{ $inputNameSelector->getPresentButEmptyInputName() }}" name="{{ $inputNameSelector->getPresentButEmptyInputName() }}" value="">
+                    <input wire:model="honeyInputs.{{ $inputNameSelector->getTimeOfPageLoadInputName() }}" name="{{ $inputNameSelector->getTimeOfPageLoadInputName() }}" value="{{ $timeOfPageLoadValue() }}">
+                    <input wire:model="honeyInputs.{{ $inputNameSelector->getJavascriptInputName() }}" data-purpose="{{ $inputNameSelector->getJavascriptInputName() }}" name="{{ $inputNameSelector->getJavascriptInputName() }}" value="">
                     {{ $slot }}
                 </div>
                 @isset($attributes['recaptcha'])

--- a/src/Views/Recaptcha.php
+++ b/src/Views/Recaptcha.php
@@ -25,7 +25,7 @@ class Recaptcha extends Component
                         recaptcha(el, action = 'submit') {
                             grecaptcha.execute('{{ $siteKey() }}', { action }).then(token => {
                                 el.value = token;
-                                el.dispatchEvent(new Event('change'));
+                                el.dispatchEvent(new Event('input'));
                             });
                         },
                         recaptchaInputs() {
@@ -43,14 +43,14 @@ class Recaptcha extends Component
                         })
                     });
 
-                    document.addEventListener('livewire:load', function () {
+                    document.addEventListener('livewire:init', function () {
                         window.addEventListener('recaptcha-refresh-required', () => {
                             window.Honey.refreshAllTokens();
                         });
                     });
                 </script>
             @endonce
-            <input wire:model.lazy.defer="honeyInputs.{{ $inputName }}"
+            <input wire:model="honeyInputs.{{ $inputName }}"
                    {{ $attributes }}
                    type="hidden"
                    data-purpose="honey-rc"

--- a/tests/Livewire/HoneyFormTraitTest.php
+++ b/tests/Livewire/HoneyFormTraitTest.php
@@ -88,7 +88,7 @@ class HoneyFormTraitTest extends TestCase
     }
     
     /** @test */
-    public function when_the_recaptcha_token_is_checked_a_browser_event_is_dispatched()
+    public function when_the_recaptcha_token_is_checked_an_event_is_dispatched()
     {
         Http::fake(['*' => [
             'success' => true,
@@ -101,11 +101,11 @@ class HoneyFormTraitTest extends TestCase
 
         $test = Livewire::test(AnotherExample::class);
         $test->call('checkRecaptcha');
-        $test->assertDispatchedBrowserEvent('recaptcha-refresh-required');
+        $test->assertDispatched('recaptcha-refresh-required');
     }
 
     /** @test */
-    public function when_recaptcha_is_checked_manually_in_a_livewire_component_a_browser_event_is_dispatched()
+    public function when_recaptcha_is_checked_manually_in_a_livewire_component_an_event_is_dispatched()
     {
         Http::fake(['*' => [
             'success' => true,
@@ -118,7 +118,7 @@ class HoneyFormTraitTest extends TestCase
 
         $test = Livewire::test(AnotherExample::class);
         $test->call('manualRecaptchaCheck');
-        $test->assertDispatchedBrowserEvent('recaptcha-refresh-required');
+        $test->assertDispatched('recaptcha-refresh-required');
     }
 }
 


### PR DESCRIPTION
This drop the compatibility with Livewire 2, which means it will probably require a new version release.

I couldn't test the re-captcha part as we don't use it. If someone could test it before it would be nice.

Note: I had to change the input event to `input` instead of `change` has it wasn't registered by `wire:model.(lazy|change)` or `wire:model` with Livewire 3 but the `input` event was. I haven't dig why. _(tested on firefox and brave)_

Edit: I suppose PHP 7.0 should be dropped as well for this new release.

--
Thanks for your package ! It works well for us :heart: 